### PR TITLE
refactor: avoid using `is` static class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import {dom} from './dom/dom';
 import {DomWatcher} from './dom/dom-watcher';
 import {bom} from './dom/bom';
 import {mathf} from './mathf/mathf';
-import {is} from './is/is';
+import * as is from './is/is';
 import {func} from './func/func';
 import {time} from './time/time';
 import {Raf} from './raf/raf';

--- a/src/mathf/color.ts
+++ b/src/mathf/color.ts
@@ -1,5 +1,5 @@
 import {mathf} from './mathf';
-import {is} from '../is/is';
+import * as is from '../is/is';
 
 export interface ColorRGBA {
   r: number;


### PR DESCRIPTION
This refactor helps with tree shaking since any methods using the static class import will end up exporting all members of the `is` module.