### PR TITLE
feat: Start subsequent raf run if necessary

### DIFF
--- a/src/raf/raf.ts
+++ b/src/raf/raf.ts
@@ -697,6 +697,15 @@ class RafRegistry {
     RafRegistry.runRafCallbacks(this.postWrites);
 
     this.flushScheduled = false;
+
+    if (
+      this.preReads.length ||
+      this.reads.length ||
+      this.writes.length ||
+      this.postWrites.length
+    ) {
+      this.start();
+    }
   }
 
   /**


### PR DESCRIPTION
This allows for an earlier step to be scheduled during
the callback for a later step. For example scheduling a
read() callback during a postWrite() callback.