### PR TITLE
feat: Carousel pauses if condition not met

### DIFF
--- a/src/ui/carousel/carousel.ts
+++ b/src/ui/carousel/carousel.ts
@@ -652,7 +652,11 @@ export class Carousel implements EventDispatcher {
   private onRaf(): void {
     this.raf.read(() => {
       if (!this.condition()) {
+        // Don't continue autoplay timing when the carousel isn't running
+        this.pause();
         return;
+      } else {
+        this.unpause();
       }
 
       if (this.isBeingInteractedWith()) {

--- a/src/ui/carousel/carousel.ts
+++ b/src/ui/carousel/carousel.ts
@@ -107,6 +107,13 @@ class AutoplayTimeout {
    * Disable the timeout to pause the autplay.
    */
   pause(): void {
+    // We check if the carousel is already paused to ensure pause() is safe to
+    // call multiple times.
+    // If not the value in timePassed slowly accumulates with the time between
+    // pause() calls.
+    if (this.isPaused()) {
+      return;
+    }
     this.timePassed += +new Date() - this.lastStartTime;
     this.clear();
   }


### PR DESCRIPTION
Carousels with conditions set by inview were immediately
transitioning to the next slide as soon as they were visible.
This was being caused by the autoplayTimeout continuing to
tick down while the carousel was out of view.