### PR TITLE
Add lit component boostrap

### DIFF
--- a/examples/degu-image.js
+++ b/examples/degu-image.js
@@ -1,9 +1,9 @@
 
- import { DeguImage} from '../lib/lit/image';
+ import { register} from '../lib/lit/lit';
 
 export default class DeguImageSample {
 
   constructor() {
-    window.customElements.define('degu-image', DeguImage);
+    register();
   }
 }

--- a/src/lit/lit.ts
+++ b/src/lit/lit.ts
@@ -1,0 +1,12 @@
+import {DeguImage} from './image';
+
+const defaultComponents: Record<string, typeof HTMLElement> = {
+  'degu-image': DeguImage,
+};
+
+export const register = (components = defaultComponents) => {
+  for (const key in components) {
+    !window.customElements.get(key) &&
+      window.customElements.define(key, components[key]);
+  }
+};


### PR DESCRIPTION
Adds a simple way to declare all degu lit components.

```
 import { register} from '../lib/lit/lit';
 
 // Called once.
 register();
 ```
 
 Drawbacks:
 - imports all degu lit components which could be large as the library grows
 