### PR TITLE
Add redirect capabilities to youtube-modal

### DIFF
--- a/examples/components.html
+++ b/examples/components.html
@@ -79,7 +79,7 @@
   <div class="section" id="youtube-modal-section">
     <div class="section__header">Degu Youtube Modal</div>
     <button youtube-modal="8Qn_spdM5Zg">Watch StarWars</button>
-    <button youtube-modal="TcMBFSGVi1c">Watch Avengers</button>
+    <button youtube-modal="TcMBFSGVi1c" youtube-modal-redirect-mobile="false">Watch Avengers</button>
   </div>
 
 </body>

--- a/src/components/youtube-modal.ts
+++ b/src/components/youtube-modal.ts
@@ -4,6 +4,7 @@ import {query} from 'lit/decorators.js';
 import {DeguYouTubeInline} from './youtube-inline';
 import {DomWatcher} from '../dom/dom-watcher';
 import * as dom from '../dom/dom';
+import * as is from '../is/is';
 
 /**
  * DeguYutubeModal wraps details-dialog-element and degu-youtube-inline.
@@ -65,6 +66,20 @@ export class DeguYouTubeModal extends LitElement {
       (el: HTMLElement) => {
         const youtubeModalId = el.getAttribute('youtube-modal');
         if (youtubeModalId) {
+          // If the clicked element has the attribute
+          // `youtube-modal-redirect-mobile` redirect the user to youtube
+          // instead of opening a modal.
+          const REDIRECT_ATTRIBUTE = 'youtube-modal-redirect-mobile';
+          const redirectAttributeValue = el.getAttribute(REDIRECT_ATTRIBUTE);
+          const shouldRedirectToYoutube =
+            redirectAttributeValue === 'true' || redirectAttributeValue === '';
+
+          if (shouldRedirectToYoutube && is.mobile()) {
+            const redirectUrl = `https://m.youtube.com/watch?v=${youtubeModalId}`;
+            window.location.href = redirectUrl;
+            return;
+          }
+
           // Attach this element if it is not in the dom yet.
           if (!this.isConnected) {
             this.host.appendChild(this);


### PR DESCRIPTION
Small upgrade to keep youtube-modal consistent with airkit version.

Adding the attribute `youtube-modal-redirect-mobile="true"` or having the attribute `youtube-modal-redirect-modal` will redirect users to youtube (and the app if they have it installed)

```
 <button youtube-modal="TcMBFSGVi1c" youtube-modal-redirect-mobile="true">Watch Avengers</button>
```