### PR TITLE
fix: degu-image should calculate the max of the container and image

### DIFF
--- a/src/components/image.ts
+++ b/src/components/image.ts
@@ -143,7 +143,11 @@ export class DeguImage extends LitElement {
   private onResize() {
     // Calculate the width to the nearest 50 pixel.
     // Example: 420 --> 450, 451 --> 500
-    const width = Math.ceil(this.offsetWidth / 50) * 50;
+    const image = this.querySelector('img');
+    const width =
+      Math.ceil(
+        Math.max(this.offsetWidth, image ? image.offsetWidth : 0) / 50
+      ) * 50;
 
     // Calculate the autowidth render size and take the historical maximum.
     this.autoRenderWidth = Math.max(


### PR DESCRIPTION
Degu image can miscalculate autowidth sizes if the developer has css that makes the image larger than the `degu-image` container.

For example:

```
<degu-image> <img></degu-image>

degu-image img
  position: absolute
  width: 100%
  height: 100%
```
Results in the container offsetWidth being smaller than the image itself.

This fixes problem by taking the larger of the container and image as the basis of autowidth calculation.

