### PR TITLE
Start observer before running an update

### DIFF
--- a/src/ui/component-registry.ts
+++ b/src/ui/component-registry.ts
@@ -69,13 +69,13 @@ export class ComponentRegistry {
 
   /** Starts the component registry. */
   start() {
-    this.update();
     this.observer.observe(document.body, {
       attributes: true,
       attributeFilter: ['data-component'],
       subtree: true,
       childList: true,
     });
+    this.update();
   }
 
   /** Stops the component registry observer. */


### PR DESCRIPTION
Working with Jon we noticed a problem where a registered Component created a new Component that was not initialized.

Detecting the issue can be complicated by BrowserSync which was causing a mutation on localhost resulting in everything missed being initialized.

Having the observer start before the first update should resolve this issue but there is a non-zero chance of issues if code using the ComponentRegistry is relying on the first update being skipped.