### PR TITLE
Support checks on slot in closestElementComposed

### DIFF
--- a/src/dom/dom.ts
+++ b/src/dom/dom.ts
@@ -1221,7 +1221,14 @@ export function closestElementComposed(selector, baseElement) {
     if (!baseElement || baseElement === document || baseElement === window)
       return null;
     const found = baseElement.closest(selector);
-    return found ? found : closestFrom(baseElement.getRootNode().host);
+    if (found) {
+      return found;
+    }
+    const foundClosestFromSlot = closestFrom(baseElement.assignedSlot);
+    if (foundClosestFromSlot) {
+      return foundClosestFromSlot;
+    }
+    return closestFrom(baseElement.getRootNode().host);
   }
   return closestFrom(baseElement);
 }


### PR DESCRIPTION
Check for closest while factoring in the assigned slot.

Handles a case like:
```
<custom-element>
  <tile slot="tile"></tile>
</custom-element>
```

Where `<custom-element>` renders:
```
render() {
  return html`
    <mosaic radius="20">
      <slot name="tile"></slot>
    </mosaic>
  `;
}
``

Where the `tile` is looking to pull its radius from a parent `mosaic` element.